### PR TITLE
Translate components to English

### DIFF
--- a/components/AboutFeatures.vue
+++ b/components/AboutFeatures.vue
@@ -2,12 +2,12 @@
 <section class="w-full">
   <div class="max-w-xl p-6 mx-auto pt-14 pb-24 lg:pt-24 lg:pb-32 px-4 lg:max-w-6xl">
     <div>
-      <h2 class="text-3xl font-bold tracking-tight text-black sm:text-4xl md:text-5xl">Dlaczego 
+      <h2 class="text-3xl font-bold tracking-tight text-black sm:text-4xl md:text-5xl">Why
         <span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">
-            warto? 
+            choose us?
         </span>
         </h2>
-      <p class="text-xl lg:text-2xl mt-6 font-light">Co wyróżnia instantroom i czyni wyjątkowym?</p>
+      <p class="text-xl lg:text-2xl mt-6 font-light">What makes Instantroom stand out and unique?</p>
     </div>
     <div class="grid lg:gap-8 lg:grid-cols-2 lg:items-center">
       <div>
@@ -19,8 +19,8 @@
             </div>
             </div>
             <div class="ml-4">
-              <h4 class="text-2xl lg:text-2xl font-medium leading">Każdy projekt jest unikalny</h4>
-              <p class="mt-4 text-lg font-light tracking-tight sm:mt-2 sm:text-xl lg:text-lg xl:text-2xl"> ...i dostosowany do Twoich potrzeb. Wizualizacje są tworzone na <span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">podstawie Twojego pomieszczenia,</span> czyli uwzględniają kształt pomieszczenia i nierzadko przekształcają meble widoczne na zdjęciu.</p>
+              <h4 class="text-2xl lg:text-2xl font-medium leading">Every project is unique</h4>
+              <p class="mt-4 text-lg font-light tracking-tight sm:mt-2 sm:text-xl lg:text-lg xl:text-2xl"> ...and tailored to your needs. Visualizations are created on <span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">the basis of your room,</span> taking into account its shape and often transforming the furniture visible in the photo.</p>
             </div>
           </div>
           <div class="flex">
@@ -30,8 +30,8 @@
             </div>
             </div>
             <div class="ml-4">
-              <h4 class="text-2xl lg:text-2xl font-medium leading">Twoje generacje nie będą posiadały znaku wodnego</h4>
-              <p class="mt-4 text-lg font-light tracking-tight  sm:mt-2 sm:text-xl lg:text-lg xl:text-2xl">a ty będziesz mógł/a je wykorzystywać zarówno do użytku osobistego jak i komercyjnego.</p>
+              <h4 class="text-2xl lg:text-2xl font-medium leading">Your generations will not have a watermark</h4>
+              <p class="mt-4 text-lg font-light tracking-tight  sm:mt-2 sm:text-xl lg:text-lg xl:text-2xl">and you can use them for both personal and commercial purposes.</p>
             </div>
           </div>
           <div class="flex">
@@ -41,8 +41,8 @@
             </div>
             </div>
             <div class="ml-4">
-              <h4 class="text-2xl lg:text-2xl font-medium leading">Oszczędź czas i nerwy!</h4>
-              <p class="mt-4 text-lg font-light tracking-tight  sm:mt-2 sm:text-xl lg:text-lg xl:text-2xl"> Jeśli męczy Cię przeczesywanie internetu w poszukiwaniu inspiracji do remontu, przeglądanie setek stron i zdjęć, nasz AI Room Decorator jest dla Ciebie rozwiązaniem! Nie trać dłużej czasu i za pomocą kilku kliknięć, sprawdź jak zaprezentuje się Twój salon w stylu boho, modernistycznym, czy glamour.</p>
+              <h4 class="text-2xl lg:text-2xl font-medium leading">Save time and nerves!</h4>
+              <p class="mt-4 text-lg font-light tracking-tight  sm:mt-2 sm:text-xl lg:text-lg xl:text-2xl"> If you're tired of combing the internet for renovation inspiration, browsing hundreds of pages and photos, our AI Room Decorator is the solution for you! Don't waste time anymore and with just a few clicks, see how your living room looks in boho, modern, or glamour style.</p>
             </div>
           </div>
           <div class="flex">
@@ -52,8 +52,8 @@
             </div>
             </div>
             <div class="ml-4">
-              <h4 class="text-2xl lg:text-2xl font-medium leading">Pierwsze 3 wizualizacje masz zupełnie za darmo!</h4>
-              <p class="mt-4 ext-lg font-light tracking-tight sm:mt-2 sm:text-xl text-lg xl:text-2xl"><span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">Bez kruczków, bez płatności.</span>  Jeśli nasze narzędzie Ci się spodoba, oczywiście zachęcamy do wykupienia tokenów!</p>
+              <h4 class="text-2xl lg:text-2xl font-medium leading">The first 3 visualizations are completely free!</h4>
+              <p class="mt-4 ext-lg font-light tracking-tight sm:mt-2 sm:text-xl text-lg xl:text-2xl"><span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">No gimmicks, no payments.</span> If you like our tool, we encourage you to purchase tokens!</p>
             </div>
           </div>
         </div>

--- a/components/BgCta.vue
+++ b/components/BgCta.vue
@@ -10,12 +10,12 @@
         <div class="mt-10">
             <NuxtLink v-if="isLoggedIn" to="/design">
                 <UButton variant="solid"  class="mt-4 finline-block bg-white py-3 px-8 border border-transparent rounded-md text-base font-medium text-red-500 hover:bg-gray-100 hover:text-red-600">
-                <UIcon width="24" height="24" name="fluent:paint-brush-arrow-down-24-filled" dynamic /> Rozpocznij projekt
+                <UIcon width="24" height="24" name="fluent:paint-brush-arrow-down-24-filled" dynamic /> Start project
                 </UButton>
             </NuxtLink>
             <NuxtLink v-else to="/login">
                 <UButton variant="solid"  class="mt-4 finline-block bg-white py-3 px-8 border border-transparent rounded-md text-base font-medium text-red-500 hover:bg-gray-100 hover:text-red-600">
-                <UIcon width="24" height="24" name="fluent:paint-brush-arrow-down-24-filled" dynamic /> Rozpocznij projekt
+                <UIcon width="24" height="24" name="fluent:paint-brush-arrow-down-24-filled" dynamic /> Start project
                 </UButton>
             </NuxtLink>
         </div>
@@ -27,11 +27,11 @@
 const props = defineProps({
   heading: {
     type: String,
-    default: '3 pierwsze wizualizacje są za darmo.',
+    default: 'The first 3 visualizations are free.',
   },
   description: {
     type: String,
-    default: 'Bez kruczków. Bez podawania danych płatniczych.',
+    default: 'No gimmicks. No payment details required.',
   },
 });
 

--- a/components/PortfolioExamples.vue
+++ b/components/PortfolioExamples.vue
@@ -1,15 +1,15 @@
 <template>
   <section id="portfolio" class="portfolio-section pt-14 pb:24 lg:pt-24 lg:pb-32 px-4 w-full max-w-6xl">
     <div class="mx-auto w-full">
-      <!-- Tytuł sekcji -->
-      <div class="text-center mb-12">
-        <h2 class="text-3xl lg:text-4xl xl:text-5xl font-bold leading-none mb-4">Przykładowe
-          <span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">wizualizacje</span>
-        </h2>
-        <p class="text-xl lg:text-2xl mt-3 font-light">Przygotuj się na remont bez stresu – z Instant Room masz wszystko pod kontrolą, a do tego odrobinę rozrywki na deser!</p>
-      </div>
+        <!-- Section title -->
+        <div class="text-center mb-12">
+          <h2 class="text-3xl lg:text-4xl xl:text-5xl font-bold leading-none mb-4">Sample
+            <span class="font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-sunsetOrange-500 to-sunsetOrange-800">visualizations</span>
+          </h2>
+          <p class="text-xl lg:text-2xl mt-3 font-light">Get ready for renovation without stress – with Instant Room you have everything under control, plus a bit of entertainment as a bonus!</p>
+        </div>
 
-      <!-- Przyciski filtrów -->
+        <!-- Filter buttons -->
       <div class="flex flex-wrap md:flex-row items-center mb-8 gap-3 justify-center">
         <button v-for="category in categories" :key="category" @click="setActiveCategory(category)" :class="{
           'bg-aquaBlue-500 text-white': activeCategory === category,
@@ -19,7 +19,7 @@
         </button>
       </div>
 
-      <!-- Lista projektów -->
+        <!-- Project list -->
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
         <div v-for="(project, index) in visibleProjects" :key="index"
              class="group portfolio-item relative hover:shadow-lg shadow-md rounded-lg overflow-hidden"
@@ -33,13 +33,13 @@
         </div>
       </div>
 
-      <!-- Przycisk Wczytaj więcej -->
-      <div class="text-center mt-8 mb-4 lg:mb-0" v-if="hasMoreProjects">
-        <UButton @click="loadMoreProjects" variant="solid" class="focus:shadow-outline focus:outline-none tracking-wide font-semibold bg-sunsetOrange-500 hover:bg-sunsetOrange-700 text-gray-100 py-4 rounded-lg transition-all duration-300 ease-in-out text-lg px-4">
-          <UIcon width="24" height="24" :name="'mdi:chevron-double-down'" dynamic />
-          Wczytaj więcej
-        </UButton>
-      </div>
+        <!-- Load more button -->
+        <div class="text-center mt-8 mb-4 lg:mb-0" v-if="hasMoreProjects">
+          <UButton @click="loadMoreProjects" variant="solid" class="focus:shadow-outline focus:outline-none tracking-wide font-semibold bg-sunsetOrange-500 hover:bg-sunsetOrange-700 text-gray-100 py-4 rounded-lg transition-all duration-300 ease-in-out text-lg px-4">
+            <UIcon width="24" height="24" :name="'mdi:chevron-double-down'" dynamic />
+            Load more
+          </UButton>
+        </div>
     </div>
 
     <!-- Modal -->
@@ -71,7 +71,7 @@ const { data, pending, error } = useFetch('/api/projects');
 const projects = computed(() => data.value?.projects || []);
 const categories = computed(() => data.value?.categories || []);
 
-const activeCategory = ref('Salon');
+const activeCategory = ref('Living Room');
 const visibleProjectsCount = ref(6); 
 const generateTitleFromFilename = (filename) => {
   const fileNameWithoutPath = filename.split('/').pop();
@@ -82,7 +82,7 @@ const generateTitleFromFilename = (filename) => {
 };
 
 const filteredProjects = computed(() => {
-  if (activeCategory.value === 'Wszystkie') {
+  if (activeCategory.value === 'All') {
     return projects.value;
   }
   return projects.value.filter((project) =>

--- a/components/WhyUs.vue
+++ b/components/WhyUs.vue
@@ -22,7 +22,7 @@
           class="grid lg:grid-cols-2 lg:gap-10 lg:items-center"
           :class="{ 'lg:flex-row-reverse': index % 2 === 1 }"
         >
-          <!-- Tekst -->
+          <!-- Text -->
           <div :class="index % 2 === 1 ? 'lg:order-2' : ''">
             <div class="flex">
               <div class="flex-shrink-0">
@@ -70,15 +70,15 @@ import ComparisonSlider from '@/components/ComparisonSlider.vue'
 const props = defineProps({
   heading: {
     type: String,
-    default: 'Dlaczego',
+    default: 'Why',
   },
   highlighted: {
     type: String,
-    default: 'warto?',
+    default: 'choose us?',
   },
   subtitle: {
     type: String,
-    default: 'Co wyróżnia Instantroom i czyni wyjątkowym?',
+    default: 'What sets Instantroom apart and makes it unique?',
   },
   items: {
     type: Array,


### PR DESCRIPTION
## Summary
- translate sample portfolio section text to English
- update call-to-action and benefits sections with English copy
- convert "Why Us" defaults to English wording

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple prettier/prettier errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_6895f8f6283c832cada46a2794381a69