### PR TITLE
feat: localize example gallery

### DIFF
--- a/components/ExampleGallery.vue
+++ b/components/ExampleGallery.vue
@@ -2,12 +2,12 @@
     <div class="w-full md:w-auto">
       <UButton
         v-if="!changeImgView"
-        label="Open"
+        :label="t('exampleGallery.open')"
         @click="isModalExample = true"
         class="rounded-lg text-center bg-aquaBlue-500 transition-all hover:bg-aquaBlue-700 py-3 w-auto mx-auto flex justify-center"
       >
         <UIcon class="w-5 h-5 mr-3" name="material-symbols:photo-library-rounded" dynamic />
-        Użyj jednego z naszych!
+        {{ t('exampleGallery.useOneOfOurs') }}
       </UButton>
       <div v-else>
         <UIcon
@@ -31,7 +31,8 @@
         <div class="flex flex-wrap md:flex-nowrap relative">
           <div v-if="examplePhotos.length" class="flex flex-col justify-between p-4 w-full">
             <h2 class="text-2xl font-semibold text-center md:text-left">
-              Galeria przykładowych  <span class="text-sunsetOrange-500">pomieszczeń</span>
+              {{ t('exampleGallery.heading.pre') }}
+              <span class="text-sunsetOrange-500">{{ t('exampleGallery.heading.highlight') }}</span>
             </h2>
             <div class="grid grid-cols-12 pl-0 p-4 place-items-center gap-2">
               <img
@@ -58,6 +59,7 @@
   
   <script setup>
   const supabase = useSupabaseClient();
+  const { t } = useI18n();
   const props = defineProps({
     changeImgView: {
       type: Boolean,
@@ -88,7 +90,7 @@
     });
   
     if (error) {
-      console.error("Błąd pobierania plików z bucketa:", error.message);
+      console.error(t('exampleGallery.errorFetchingFiles'), error.message);
       return;
     }
   

--- a/configs/i18n.js
+++ b/configs/i18n.js
@@ -109,6 +109,15 @@ export const messages = {
       imageSelected: "Pomyślnie wybrano obraz z galerii",
       warmingUp: "Rozgrzewanie",
     },
+    exampleGallery: {
+      open: "Otwórz",
+      useOneOfOurs: "Użyj jednego z naszych!",
+      heading: {
+        pre: "Galeria przykładowych",
+        highlight: "pomieszczeń",
+      },
+      errorFetchingFiles: "Błąd pobierania plików z bucketa:",
+    },
     faq: {
       title: {
         highlight: "Najczęściej",
@@ -229,6 +238,15 @@ export const messages = {
       errorFetchingThemes: "Error fetching themes",
       imageSelected: "Image successfully selected from the gallery",
       warmingUp: "Warming up",
+    },
+    exampleGallery: {
+      open: "Open",
+      useOneOfOurs: "Use one of ours!",
+      heading: {
+        pre: "Sample gallery of",
+        highlight: "rooms",
+      },
+      errorFetchingFiles: "Error fetching files from bucket:",
     },
     faq: {
       title: {


### PR DESCRIPTION
## Summary
- localize example gallery component using i18n
- add exampleGallery keys in i18n config

## Testing
- `pnpm lint` *(fails: Prettier formatting errors)*
- `node -e "import('./configs/i18n.js').then(m=>{console.log('PL:',m.messages.pl.exampleGallery.open);console.log('EN:',m.messages.en.exampleGallery.open);})"`


------
https://chatgpt.com/codex/tasks/task_e_689759b1f02c832c9446022afa7b8ae3